### PR TITLE
Select between ._fit() of .fit() depending on the sklearn version used

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.3.2 - Fixed compliance with sklearn 1.3.0
+
+ * Fixed `AttributeError: 'super' object has no attribute 'fit' `. 
+   PR [#16](https://github.com/smarie/python-m5p/pull/16) by [lccatala](https://github.com/lccatala)
+
 ### 0.3.1 - Fixed compliance with sklearn 1.1.0
 
  * Fixed `TypeError: fit() got an unexpected keyword argument 'X_idx_sorted'`. 

--- a/src/m5py/main.py
+++ b/src/m5py/main.py
@@ -17,9 +17,14 @@ from sklearn.tree._classes import DTYPE
 from sklearn.tree._tree import DOUBLE
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
-from sklearn import __version__ as sklearn_version
+import sklearn.__version__
 
 from m5py.linreg_utils import linreg_model_to_text, DeNormalizableMixIn, DeNormalizableLinearRegression
+
+from packaging.version import Version
+
+SKLEARN_VERSION = Version(sklearn.__version__)
+SKLEARN13_OR_GREATER = SKLEARN_VERSION >= Version("1.3.0")
 
 
 __all__ = ["M5Base", "M5Prime"]
@@ -211,11 +216,12 @@ class M5Base(BaseDecisionTree):
         if self.use_smoothing not in [False, np.bool_(False), "installed", "on_prediction"]:
             raise ValueError("use_smoothing: Unexpected value: %s, please report it as issue." % self.use_smoothing)
 
-        # Get the correct fit method name based on the sklearn version used
-        sklearn_version_tuple = tuple(map(int, sklearn_version.split('.')))
-        fit_method_name = "fit" if sklearn_version_tuple <= (1, 3) else "_fit"
 
         # (1) Build the initial tree as usual
+
+        # Get the correct fit method name based on the sklearn version used
+        fit_method_name = "_fit" if SKLEARN13_OR_GREATER else "fit"
+
         fit_method = getattr(super(M5Base, self), fit_method_name)
         fit_method(X, y, sample_weight=sample_weight, check_input=check_input)
 

--- a/src/m5py/main.py
+++ b/src/m5py/main.py
@@ -17,7 +17,7 @@ from sklearn.tree._classes import DTYPE
 from sklearn.tree._tree import DOUBLE
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
-import sklearn.__version__
+from sklearn import __version__ as sklearn_version
 
 from m5py.linreg_utils import linreg_model_to_text, DeNormalizableMixIn, DeNormalizableLinearRegression
 

--- a/src/m5py/main.py
+++ b/src/m5py/main.py
@@ -23,7 +23,7 @@ from m5py.linreg_utils import linreg_model_to_text, DeNormalizableMixIn, DeNorma
 
 from packaging.version import Version
 
-SKLEARN_VERSION = Version(sklearn.__version__)
+SKLEARN_VERSION = Version(sklearn_version)
 SKLEARN13_OR_GREATER = SKLEARN_VERSION >= Version("1.3.0")
 
 

--- a/src/m5py/main.py
+++ b/src/m5py/main.py
@@ -17,6 +17,7 @@ from sklearn.tree._classes import DTYPE
 from sklearn.tree._tree import DOUBLE
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
+from sklearn import __version__ as sklearn_version
 
 from m5py.linreg_utils import linreg_model_to_text, DeNormalizableMixIn, DeNormalizableLinearRegression
 
@@ -210,8 +211,14 @@ class M5Base(BaseDecisionTree):
         if self.use_smoothing not in [False, np.bool_(False), "installed", "on_prediction"]:
             raise ValueError("use_smoothing: Unexpected value: %s, please report it as issue." % self.use_smoothing)
 
+        # Get the correct fit method name based on the sklearn version used
+        sklearn_version_tuple = tuple(map(int, sklearn_version.split('.')))
+        fit_method_name = "fit" if sklearn_version_tuple <= (1, 3) else "_fit"
+
         # (1) Build the initial tree as usual
-        super(M5Base, self).fit(X, y, sample_weight=sample_weight, check_input=check_input)
+        fit_method = getattr(super(M5Base, self), fit_method_name)
+        fit_method(X, y, sample_weight=sample_weight, check_input=check_input)
+
 
         if self.debug_prints:
             logger.debug("(debug_prints) Initial tree:")


### PR DESCRIPTION
Fixes #15 

Scikit-learn changed their API between versions 1.2.2 and 1.3.0, replacing BaseDecisionTree.fit() with BaseDecisionTree._fit().

I check the sklearn.__version__ field before calling one or the other.